### PR TITLE
Add dark mode background

### DIFF
--- a/public/bg-logo-pattern-dark.svg
+++ b/public/bg-logo-pattern-dark.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+  <defs>
+    <pattern id="logo" width="200" height="200" patternUnits="userSpaceOnUse" patternTransform="rotate(45)">
+      <image href="/logo.png" width="80" height="80" opacity="0.04" />
+    </pattern>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#logo)" />
+</svg>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -21,7 +21,8 @@ body {
 }
 
 .dark body {
-  background: var(--background);
+  background: var(--background) url('/bg-logo-pattern-dark.svg') repeat fixed;
+  background-size: 200px 200px;
   color: var(--foreground);
 }
 


### PR DESCRIPTION
## Summary
- add a subtle repeating logo pattern for dark mode
- update global styles so light and dark themes have their own background images

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6876af0bcd788329be0d919f22c661b1