### PR TITLE
Add error code handling for API requests

### DIFF
--- a/src/services/axios.ts
+++ b/src/services/axios.ts
@@ -29,14 +29,9 @@ axiosInstance.interceptors.response.use(
       | undefined;
 
     if (data) {
-      const message =
-        (data.code && errorMessages[data.code]) ||
+        error.message = (data.code && errorMessages[data.code]) ||
         data.detail ||
         'Ocurrió un error';
-
-      if (typeof window !== 'undefined') {
-        store.dispatch(showToast({ message, color: 'red' }));
-      }
     }
 
     return Promise.reject(error);

--- a/src/services/axios.ts
+++ b/src/services/axios.ts
@@ -1,6 +1,4 @@
 import axios from 'axios';
-import { store } from '@/store';
-import { showToast } from '@/store/toastSlice';
 import errorMessages from '@/utils/errorMessages';
 
 const axiosInstance = axios.create({

--- a/src/services/axios.ts
+++ b/src/services/axios.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { store } from '@/store';
 import { showToast } from '@/store/toastSlice';
-import { errorMessages } from '@/utils/errorMessages';
+import errorMessages from '@/utils/errorMessages';
 
 const axiosInstance = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000/api',

--- a/src/services/axios.ts
+++ b/src/services/axios.ts
@@ -1,4 +1,7 @@
 import axios from 'axios';
+import { store } from '@/store';
+import { showToast } from '@/store/toastSlice';
+import { errorMessages } from '@/utils/errorMessages';
 
 const axiosInstance = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000/api',
@@ -14,5 +17,30 @@ axiosInstance.interceptors.request.use((config) => {
   }
   return config;
 });
+
+axiosInstance.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    const data = error?.response?.data as
+      | {
+          detail?: string;
+          code?: number;
+        }
+      | undefined;
+
+    if (data) {
+      const message =
+        (data.code && errorMessages[data.code]) ||
+        data.detail ||
+        'Ocurrió un error';
+
+      if (typeof window !== 'undefined') {
+        store.dispatch(showToast({ message, color: 'red' }));
+      }
+    }
+
+    return Promise.reject(error);
+  }
+);
 
 export default axiosInstance;

--- a/src/utils/errorMessages.ts
+++ b/src/utils/errorMessages.ts
@@ -1,0 +1,35 @@
+export const errorMessages: Record<number, string> = {
+  // Reservation errors
+  100: 'Error desconocido',
+  101: 'No hay disponibilidad',
+  102: 'Fechas inválidas',
+  103: 'Pago fallido',
+  104: 'Reserva no encontrada',
+
+  // Property errors
+  200: 'Fecha de check-in inválida',
+  201: 'El check-in es posterior al check-out',
+  202: 'Propiedad no encontrada',
+  203: 'Error al procesar tarifas',
+  204: 'Precio no encontrado',
+  205: 'Sin disponibilidad',
+  206: 'Habitación no encontrada',
+  207: 'Zona o propiedad requerida',
+
+  // Customer errors
+  300: 'El correo ya existe',
+  301: 'Usuario inactivo',
+  302: 'Credenciales inválidas',
+  303: 'Usuario no encontrado',
+  304: 'No autenticado',
+  305: 'Refresh token inválido',
+  306: 'Token inválido',
+
+  // Security errors
+  400: 'Acceso denegado',
+
+  // Zone errors
+  500: 'Zona no encontrada',
+  501: 'ID de zona inválido',
+  502: 'Área de zona demasiado grande',
+};

--- a/src/utils/errorMessages.ts
+++ b/src/utils/errorMessages.ts
@@ -1,4 +1,4 @@
-export const errorMessages: Record<number, string> = {
+const errorMessages: Record<number, string> = {
   // Reservation errors
   100: 'Error desconocido',
   101: 'No hay disponibilidad',
@@ -33,3 +33,5 @@ export const errorMessages: Record<number, string> = {
   501: 'ID de zona inválido',
   502: 'Área de zona demasiado grande',
 };
+
+export default errorMessages;


### PR DESCRIPTION
## Summary
- intercept backend errors from Axios
- show toast messages for known error codes
- centralize mapping of backend error codes

## Testing
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_6877fa5bb9988329abfc994265e915d8