### PR TITLE
Update property routes to use name slug

### DIFF
--- a/src/app/properties/[name]/page.tsx
+++ b/src/app/properties/[name]/page.tsx
@@ -10,7 +10,7 @@ import { DateRange, RangeKeyDict, Range } from 'react-date-range';
 import { addDays, format } from 'date-fns';
 import {
   fetchAvailability,
-  loadFullPropertyById,
+  loadFullPropertyByName,
 } from '@/store/propertiesSlice';
 import AvailabilityResult from '@/components/ui/AvailabilityResult';
 import SkeletonAvailabilityResult from '@/components/ui/skeletons/AvailabilityResultSkeleton';
@@ -26,7 +26,7 @@ import 'react-date-range/dist/theme/default.css';
 
 export default function PropertyDetailPage() {
   const params = useParams();
-  const propertyId = Number(params?.id);
+  const propertyName = params?.name as string;
 
   const dispatch = useDispatch<AppDispatch>();
   const property = useSelector(selectSelectedProperty);
@@ -48,10 +48,10 @@ export default function PropertyDetailPage() {
   const calendarRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
-    if (!property && propertyId) {
-      dispatch(loadFullPropertyById(propertyId));
+    if (!property && propertyName) {
+      dispatch(loadFullPropertyByName(propertyName));
     }
-  }, [dispatch, property, propertyId]);
+  }, [dispatch, property, propertyName]);
 
   useEffect(() => {
     if (property?.id && !hasFetched) {

--- a/src/components/reserve/StepReservationSummary.tsx
+++ b/src/components/reserve/StepReservationSummary.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
+import slugify from '@/utils/slugify';
 import { CalendarDays, Users, X, FileText } from 'lucide-react';
 import { useDispatch } from 'react-redux';
 import { AppDispatch } from '@/store';
@@ -63,8 +64,12 @@ export default function StepReservationSummary({
     router.push(`/`);
   };
 
-  const handleSearchAnotherInProperty = (propertyId: number) => {
-    router.push(`/properties/${propertyId}`);
+  const handleSearchAnotherInProperty = (
+    propertyId: number,
+    propertyName?: string
+  ) => {
+    const slug = propertyName ? slugify(propertyName) : String(propertyId);
+    router.push(`/properties/${slug}`);
   };
 
   return (
@@ -194,7 +199,9 @@ export default function StepReservationSummary({
 
             <div className="flex justify-between items-center mt-2">
               <button
-                onClick={() => handleSearchAnotherInProperty(propertyId)}
+                onClick={() =>
+                  handleSearchAnotherInProperty(propertyId, firstRes.property_name)
+                }
                 className="text-sm border pt-2 border-dozeblue text-dozeblue px-2 py-1 rounded hover:bg-dozeblue/10 transition"
               >
                 Buscar otra habitación en esta propiedad

--- a/src/components/ui/banners/PropertyBanner.tsx
+++ b/src/components/ui/banners/PropertyBanner.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image';
 import { Property } from '@/types/property';
 import { Star, Mail, MessageCircleMore, Phone, ArrowRight } from 'lucide-react';
 import Link from 'next/link';
+import slugify from '@/utils/slugify';
 
 interface PropertyBannerProps {
   property: Property;
@@ -115,7 +116,7 @@ export default function PropertyBanner({
 
           <div className="flex flex-col mr-2 md:items-end">
             <Link
-              href={`/properties/${property.id}`}
+              href={`/properties/${slugify(property.name)}`}
               className="flex justify-center items-center text-dozeblue px-4 py-2 rounded-full text-sm bg-greenlight transition mt-2 w-full sm:w-auto text-center"
             >
               Términos y Condiciones

--- a/src/components/ui/cards/PropertiesCard/PropertyCardActions.tsx
+++ b/src/components/ui/cards/PropertiesCard/PropertyCardActions.tsx
@@ -3,11 +3,11 @@
 import { useDispatch } from 'react-redux';
 import { useRouter } from 'next/navigation';
 import { setSelectedProperty } from '@/store/propertiesSlice';
+import slugify from '@/utils/slugify';
 import { ArrowRight, Phone, Mail, MessageCircleMore } from 'lucide-react';
 import { Property } from '@/types/property';
 
 interface PropertyCardActionsProps {
-  id: number;
   communication_methods: string[];
   roomsCount: number;
   fullPropertyData: Property;
@@ -24,7 +24,6 @@ const getMethodIcon = (method: string) => {
 };
 
 export default function PropertyCardActions({
-  id,
   communication_methods,
   roomsCount,
   fullPropertyData,
@@ -34,7 +33,7 @@ export default function PropertyCardActions({
 
   const handleSelect = () => {
     dispatch(setSelectedProperty(fullPropertyData));
-    router.push(`/properties/${id}`);
+    router.push(`/properties/${slugify(fullPropertyData.name)}`);
   };
 
   return (

--- a/src/services/propertiesApi.ts
+++ b/src/services/propertiesApi.ts
@@ -11,6 +11,13 @@ export const fetchPropertyById = async (id: number): Promise<Property> => {
   return response.data;
 };
 
+// Obtener propiedad por nombre (slug)
+export const fetchPropertyByName = async (name: string): Promise<Property> => {
+  const encoded = encodeURIComponent(name);
+  const response = await axios.get(`/properties/name/${encoded}`);
+  return response.data;
+};
+
 // ✅ Corregido: obtener habitaciones de propiedad específica
 export const getRooms = async (propertyId: number): Promise<Room[]> => {
   const response = await axios.get(`/properties/${propertyId}/rooms`);

--- a/src/store/propertiesSlice.ts
+++ b/src/store/propertiesSlice.ts
@@ -1,8 +1,10 @@
 import { createSlice, createAsyncThunk, PayloadAction } from '@reduxjs/toolkit';
 import {
   fetchPropertyById,
+  fetchPropertyByName,
   checkPropertyAvailability,
 } from '@/services/propertiesApi';
+import slugify from '@/utils/slugify';
 import { Property } from '@/types/property';
 import { RootState, AppDispatch } from '@/store';
 import { fetchRooms } from './roomsSlice';
@@ -68,6 +70,53 @@ export const getPropertyById = createAsyncThunk<
     }
   }
 );
+
+export const getPropertyByName = createAsyncThunk<
+  Property,
+  string,
+  { state: RootState; dispatch: AppDispatch; rejectValue: string }
+>(
+  'properties/getByName',
+  async (propertyName, { getState, dispatch, rejectWithValue }) => {
+    const state = getState();
+
+    const allZoneProperties = state.zones.data.flatMap((zone: Zone) =>
+      Array.isArray(zone.properties) ? zone.properties : []
+    );
+    const fromZone = allZoneProperties.find(
+      (p) => slugify(p.name) === propertyName
+    );
+    if (fromZone) return fromZone;
+
+    const allCached: Property[] = Object.values(
+      state.properties.propertiesByZone
+    ).flat();
+    const fromCache = allCached.find((p) => slugify(p.name) === propertyName);
+    if (fromCache) return fromCache;
+
+    try {
+      const fetched = await fetchPropertyByName(propertyName);
+      return fetched;
+    } catch (err: unknown) {
+      const errorMsg = err instanceof Error ? err.message : 'Error desconocido';
+
+      dispatch(showToast({ message: errorMsg, color: 'red' }));
+
+      return rejectWithValue(errorMsg);
+    }
+  }
+);
+
+export const loadFullPropertyByName = createAsyncThunk<
+  void,
+  string,
+  { dispatch: AppDispatch; state: RootState }
+>('properties/loadFullByName', async (propertyName, { dispatch }) => {
+  const result = await dispatch(getPropertyByName(propertyName));
+  if (getPropertyByName.fulfilled.match(result)) {
+    dispatch(fetchRooms({ propertyId: result.payload.id }));
+  }
+});
 
 export const loadFullPropertyById = createAsyncThunk<
   void,
@@ -143,6 +192,29 @@ const propertiesSlice = createSlice({
   },
   extraReducers: (builder) => {
     builder
+      .addCase(getPropertyByName.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(getPropertyByName.fulfilled, (state, action) => {
+        const property = action.payload;
+        state.selectedProperty = property;
+        state.loading = false;
+        state.error = null;
+
+        const zoneId = property.zone_id;
+        if (zoneId) {
+          const current = state.propertiesByZone[zoneId] || [];
+          const alreadyStored = current.some((p) => p.id === property.id);
+          if (!alreadyStored) {
+            state.propertiesByZone[zoneId] = [...current, property];
+          }
+        }
+      })
+      .addCase(getPropertyByName.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.payload ?? 'Error al cargar propiedad';
+      })
       .addCase(getPropertyById.pending, (state) => {
         state.loading = true;
         state.error = null;

--- a/src/utils/slugify.ts
+++ b/src/utils/slugify.ts
@@ -1,0 +1,8 @@
+export default function slugify(str: string): string {
+  return str
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}


### PR DESCRIPTION
## Summary
- fetch properties by name slug
- add slugify helper
- look up properties by name in Redux slice
- load properties by slug in detail page
- update links in banners, cards and reservation summary

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688b966a66108329a95bb792d551310e