### PR TITLE
feat: add rate id to reservations

### DIFF
--- a/src/components/ui/AvailabilityResult.tsx
+++ b/src/components/ui/AvailabilityResult.tsx
@@ -101,6 +101,7 @@ export default function AvailabilityResult() {
   const handleReserve = (
     roomType: string,
     rateIndex: number,
+    rateId: number,
     pax: number,
     total: number,
     propertyId: number,
@@ -115,6 +116,7 @@ export default function AvailabilityResult() {
         check_in: range.check_in,
         check_out: range.check_out,
         rooms: rateIndex,
+        rate_id: rateId,
         pax_count: pax,
         total_price: total,
         channel: 'WEB',
@@ -326,6 +328,7 @@ export default function AvailabilityResult() {
                     handleReserve(
                       roomType,
                       selectedIndex,
+                      rates[selectedIndex].rate_id,
                       pax,
                       total,
                       propertyId,

--- a/src/services/reservationApi.ts
+++ b/src/services/reservationApi.ts
@@ -6,12 +6,14 @@ import {
 import type { Reservation, ReservationRequest } from '@/types/reservation';
 
 const transformReservation = (reservation: ReservationData): Reservation => {
-  const { roomType, ...rest } = reservation;
+  const { roomType, roomTypeID, rate_id, rooms, ...rest } = reservation;
+  void rooms;
 
   return {
     ...rest,
     room_type: roomType,
-    room_type_id: reservation.roomTypeID,
+    room_type_id: roomTypeID,
+    rate_id,
     guest_name: reservation.guest_name ?? '',
     guest_email: reservation.guest_email ?? '',
     guest_corporate: reservation.guest_corporate ?? null,

--- a/src/store/reserveSlice.ts
+++ b/src/store/reserveSlice.ts
@@ -18,6 +18,7 @@ export interface ReservationData {
   currency: string;
   roomType: string;
   roomTypeID: number;
+  rate_id: number;
   rooms: number;
   total_price: number;
   check_in: string;

--- a/src/types/reservation.ts
+++ b/src/types/reservation.ts
@@ -5,6 +5,7 @@ export interface Reservation {
   currency: string;
   room_type: string;
   room_type_id: number;
+  rate_id: number;
   total_price: number;
   check_in: string;
   check_out: string;

--- a/src/types/roomType.ts
+++ b/src/types/roomType.ts
@@ -4,6 +4,7 @@ export interface Price {
 }
 
 export interface Rate {
+  rate_id: number;
   prices: Price[];
   restriction?: Record<string, unknown>;
 }
@@ -15,6 +16,7 @@ export interface AvailabilityItem {
   availability: number;
   rates: Rate[];
   property_id: number;
+  total_price?: number;
   images?: string[];
 }
 
@@ -35,7 +37,7 @@ export interface AvailabilityPayload {
 
 export interface TotalPricePerRoomType {
   [key: string]: {
-    rate_index: number;
+    rate_id: number;
     total_price: number;
   }[];
 }


### PR DESCRIPTION
## Summary
- include rate id in room availability types
- store and forward rate id when reserving
- send rate id to backend during reservation submission

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6893cd458f5083299ec52b0ea5faa2f0