### PR TITLE
Apply voucher discount globally and fix price formatting

### DIFF
--- a/src/components/reserve/ReservationTicket.tsx
+++ b/src/components/reserve/ReservationTicket.tsx
@@ -6,6 +6,9 @@ import { CalendarDays, MapPin, Users, FileText } from 'lucide-react';
 
 export default function ReservationTicket() {
   const reservations = useSelector((state: RootState) => state.reserve.data);
+  const voucherDiscount = useSelector(
+    (state: RootState) => state.reserve.voucherDiscount
+  );
 
   if (!reservations || reservations.length === 0) {
     return (
@@ -17,6 +20,7 @@ export default function ReservationTicket() {
 
   const guest = reservations[0];
   const totalGeneral = reservations.reduce((acc, r) => acc + r.total_price, 0);
+  const totalAfterDiscount = totalGeneral - voucherDiscount;
   return (
     <div className="bg-white dark:bg-dozegray/5 border border-dozeblue/10 dark:border-white/10 rounded-2xl shadow-md max-w-3xl mx-auto p-6 space-y-6">
       <h2 className="text-2xl font-bold text-dozeblue text-center">
@@ -78,15 +82,20 @@ export default function ReservationTicket() {
               {res.pax_count > 1 ? 'es' : ''}
             </p>
             <p className="font-semibold text-dozeblue text-sm">
-              Total: ${res.total_price}
+              Total: ${res.total_price.toFixed(2)}
             </p>
           </div>
         ))}
       </div>
 
       {/* Total general */}
+      {voucherDiscount > 0 && (
+        <div className="text-right text-dozeblue font-bold text-sm">
+          Descuento voucher: -${voucherDiscount.toFixed(2)}
+        </div>
+      )}
       <div className="text-right text-dozeblue font-bold text-sm">
-        Total general pagado: ${totalGeneral}
+        Total general pagado: ${totalAfterDiscount.toFixed(2)}
       </div>
 
       {/* Términos y condiciones */}

--- a/src/components/reserve/StepReservationSummary.tsx
+++ b/src/components/reserve/StepReservationSummary.tsx
@@ -4,8 +4,8 @@ import { useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import slugify from '@/utils/slugify';
 import { CalendarDays, Users, X, FileText } from 'lucide-react';
-import { useDispatch } from 'react-redux';
-import { AppDispatch } from '@/store';
+import { useDispatch, useSelector } from 'react-redux';
+import { AppDispatch, RootState } from '@/store';
 import { ReservationData } from '@/store/reserveSlice';
 import { fetchAvailability } from '@/store/propertiesSlice';
 import Image from 'next/image';
@@ -28,6 +28,9 @@ export default function StepReservationSummary({
 }: Props) {
   const router = useRouter();
   const dispatch = useDispatch<AppDispatch>();
+  const voucherDiscount = useSelector(
+    (state: RootState) => state.reserve.voucherDiscount
+  );
 
   const [openGallery, setOpenGallery] = useState(false);
   const [galleryImages, setGalleryImages] = useState<string[]>([]);
@@ -45,6 +48,10 @@ export default function StepReservationSummary({
   const totalGeneral = useMemo(
     () => reservations.reduce((sum, r) => sum + r.total_price, 0),
     [reservations]
+  );
+  const totalAfterDiscount = useMemo(
+    () => totalGeneral - voucherDiscount,
+    [totalGeneral, voucherDiscount]
   );
 
   const handleAddReservation = async () => {
@@ -189,8 +196,8 @@ export default function StepReservationSummary({
                         </div>
                       </div>
                     </div>
-                    <div className="mt-3 sm:ml-119 text-dozeblue font-bold text-lg sm:text-xl">
-                      ${res.total_price}
+                    <div className="mt-3 self-end text-dozeblue font-bold text-lg sm:text-xl">
+                      ${res.total_price.toFixed(2)}
                     </div>
                   </div>
                 </div>
@@ -207,7 +214,7 @@ export default function StepReservationSummary({
                 Buscar otra habitación en esta propiedad
               </button>
               <span className="text-sm font-bold pl-3 text-dozeblue">
-                Total propiedad {propertyId}: ${totalProperty}
+                Total propiedad {propertyId}: ${totalProperty.toFixed(2)}
               </span>
             </div>
 
@@ -271,8 +278,13 @@ export default function StepReservationSummary({
         );
       })}
 
+      {voucherDiscount > 0 && (
+        <div className="flex justify-end text-dozeblue font-bold text-sm">
+          Descuento voucher: -${voucherDiscount.toFixed(2)}
+        </div>
+      )}
       <div className="flex justify-end text-dozeblue font-bold text-sm">
-        Total general: ${totalGeneral}
+        Total general: ${totalAfterDiscount.toFixed(2)}
       </div>
 
       <div className="flex flex-wrap justify-between gap-2 mt-4">

--- a/src/components/ui/VoucherOrLoginPrompt.tsx
+++ b/src/components/ui/VoucherOrLoginPrompt.tsx
@@ -1,18 +1,23 @@
 'use client';
 
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { RootState } from '@/store';
+import { setVoucherDiscount } from '@/store/reserveSlice';
 
 export default function VoucherOrLoginPrompt() {
   const profile = useSelector((state: RootState) => state.customer.profile);
   const router = useRouter();
   const [voucher, setVoucher] = useState('');
+  const dispatch = useDispatch();
 
   const handleVoucherSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    console.log('Código ingresado:', voucher);
+    const amount = parseFloat(voucher.replace(/[^0-9.]/g, ''));
+    if (!isNaN(amount)) {
+      dispatch(setVoucherDiscount(amount));
+    }
   };
 
   if (!profile) {

--- a/src/store/reserveSlice.ts
+++ b/src/store/reserveSlice.ts
@@ -55,11 +55,13 @@ export interface RedsysData {
 interface ReserveState {
   data: ReservationData[];
   redsysData: RedsysData | null;
+  voucherDiscount: number;
 }
 
 const initialState: ReserveState = {
   data: [],
   redsysData: null,
+  voucherDiscount: 0,
 };
 
 const reserveSlice = createSlice({
@@ -91,6 +93,9 @@ const reserveSlice = createSlice({
     setRedsysData(state, action: PayloadAction<RedsysData>) {
       state.redsysData = action.payload;
     },
+    setVoucherDiscount(state, action: PayloadAction<number>) {
+      state.voucherDiscount = action.payload;
+    },
   },
 });
 
@@ -101,6 +106,7 @@ export const {
   deleteReservation,
   clearReservations,
   setRedsysData,
+  setVoucherDiscount,
 } = reserveSlice.actions;
 
 export default reserveSlice.reducer;


### PR DESCRIPTION
## Summary
- Add `voucherDiscount` to reservation store with setter
- Parse voucher code and store discount from input
- Align price fields and format amounts to two decimals, applying vouchers to overall total

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893d2935434832994daa17a4ddf9cfa