### PR TITLE
Enable reverse navigation and reset discount

### DIFF
--- a/src/app/reserve/page.tsx
+++ b/src/app/reserve/page.tsx
@@ -4,7 +4,11 @@ import { useState, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { RootState, AppDispatch } from '@/store';
-import { deleteReservation, updateReservation } from '@/store/reserveSlice';
+import {
+  deleteReservation,
+  updateReservation,
+  clearDiscount,
+} from '@/store/reserveSlice';
 import StepReservationSummary from '@/components/reserve/StepReservationSummary';
 import StepGuestDetails from '@/components/reserve/StepGuestDetails';
 import StepConfirmation from '@/components/reserve/StepConfirmation';
@@ -29,6 +33,13 @@ export default function ReservePage() {
   const goBack = () => setCurrentStep((prev) => Math.max(prev - 1, 0));
 
   useEffect(() => {
+    router.replace(`?step=${currentStep}`, { scroll: false });
+    if (currentStep === 0) {
+      dispatch(clearDiscount());
+    }
+  }, [currentStep, dispatch, router]);
+
+  useEffect(() => {
     reservations.forEach((res, index) => {
       if (!res.terms_and_conditions) {
         const property = zones
@@ -50,6 +61,8 @@ export default function ReservePage() {
     });
   }, [reservations, zones, dispatch]);
 
+  if (reservations.length === 0) return null;
+
   return (
     <div className="max-w-4xl mx-auto p-6 space-y-8">
       {/* Stepper */}
@@ -59,7 +72,15 @@ export default function ReservePage() {
           const isCompleted = index < currentStep;
 
           return (
-            <div key={index} className="flex items-center w-full">
+            <div
+              key={index}
+              className={`flex items-center w-full ${
+                index < currentStep ? 'cursor-pointer' : ''
+              }`}
+              onClick={() => {
+                if (index < currentStep) setCurrentStep(index);
+              }}
+            >
               <div className="flex items-center gap-2">
                 <div
                   className={`w-7 h-7 flex items-center justify-center rounded-full border text-sm font-semibold transition-all duration-300 ${

--- a/src/store/reserveSlice.ts
+++ b/src/store/reserveSlice.ts
@@ -99,6 +99,9 @@ const reserveSlice = createSlice({
       state.redsysData = null;
       state.discount = null;
     },
+    clearDiscount(state) {
+      state.discount = null;
+    },
     setRedsysData(state, action: PayloadAction<RedsysData>) {
       state.redsysData = action.payload;
     },
@@ -134,6 +137,7 @@ export const {
   updateReservations,
   deleteReservation,
   clearReservations,
+  clearDiscount,
   setRedsysData,
   applyCoupon,
   applyVoucher,


### PR DESCRIPTION
## Summary
- Allow clicking previous steps and update URL, clearing discounts when returning to cart
- Hide reservation flow when no selections exist
- Add `clearDiscount` action to reset voucher/coupon state

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Geist`)*

------
https://chatgpt.com/codex/tasks/task_e_6893db07b4588329b1d8c54c6778671f