### PR TITLE
feat(reserve): add back navigation

### DIFF
--- a/src/app/reserve/page.tsx
+++ b/src/app/reserve/page.tsx
@@ -92,6 +92,17 @@ export default function ReservePage() {
         })}
       </div>
 
+      {currentStep > 0 && (
+        <div className="pl-6">
+          <button
+            onClick={goBack}
+            className="text-dozeblue border border-dozeblue px-4 py-2 rounded-lg text-sm font-medium hover:bg-dozeblue/10 transition-colors"
+          >
+            Atrás
+          </button>
+        </div>
+      )}
+
       {/* Step content */}
       {currentStep === 0 && (
         <>


### PR DESCRIPTION
## Summary
- allow going back to a previous step in the reserve flow

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893e9315c2c8329aa16afba00f8c13c