### PR TITLE
Add property services management step

### DIFF
--- a/src/components/staff/AddPropertyWizard.tsx
+++ b/src/components/staff/AddPropertyWizard.tsx
@@ -9,6 +9,7 @@ import StepBasicInfo from './StepBasicInfo';
 import StepSelectLocation from './StepSelectLocation';
 import StepCreateProperty from './StepCreateProperty';
 import SyncPropertyForm from './SyncPropertyForm';
+import StepPropertyServices from './StepPropertyServices';
 import { motion, AnimatePresence } from 'framer-motion';
 import type { PropertyFormData } from '@/types/property';
 import type { Zone } from '@/types/zone';
@@ -26,6 +27,7 @@ const steps = [
   'Datos básicos',
   'Ubicación',
   'Crear propiedad',
+  'Servicios',
   'Sincronización',
   'Editar habitaciones',
 ];
@@ -154,12 +156,18 @@ export default function AddPropertyWizard({ startInZoneId }: Props) {
               />
             )}
             {step === 5 && createdPropertyId !== null && (
+              <StepPropertyServices
+                propertyId={createdPropertyId}
+                onNext={goNext}
+              />
+            )}
+            {step === 6 && createdPropertyId !== null && (
               <SyncPropertyForm
                 propertyId={createdPropertyId}
                 onSyncComplete={goNext}
               />
             )}
-            {step === 6 && createdPropertyId !== null && (
+            {step === 7 && createdPropertyId !== null && (
               <StepRoomEdit propertyId={createdPropertyId} />
             )}
           </motion.div>

--- a/src/components/staff/StepPropertyServices.tsx
+++ b/src/components/staff/StepPropertyServices.tsx
@@ -1,0 +1,233 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useDispatch } from 'react-redux';
+import { AppDispatch } from '@/store';
+import { showToast } from '@/store/toastSlice';
+import type { PropertyService } from '@/types/property';
+import {
+  getPropertyServices,
+  createPropertyService,
+  updatePropertyService,
+  deletePropertyService,
+  fetchAllServices,
+} from '@/services/propertiesApi';
+
+interface Props {
+  propertyId: number;
+  onNext: () => void;
+}
+
+export default function StepPropertyServices({ propertyId, onNext }: Props) {
+  const dispatch = useDispatch<AppDispatch>();
+  const [services, setServices] = useState<PropertyService[]>([]);
+  const [availableServices, setAvailableServices] = useState<PropertyService[]>([]);
+  const [form, setForm] = useState({ code: '', name: '', description: '' });
+  const [selectedExisting, setSelectedExisting] = useState<number | ''>('');
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const [propertySvcs, allSvcs] = await Promise.all([
+          getPropertyServices(propertyId),
+          fetchAllServices(),
+        ]);
+        setServices(propertySvcs);
+        setAvailableServices(allSvcs);
+      } catch (e) {
+        console.error(e);
+      }
+    };
+    load();
+  }, [propertyId]);
+
+  const handleAdd = async () => {
+    if (!form.code.trim() || !form.name.trim()) return;
+    try {
+      const created = await createPropertyService(propertyId, form);
+      setServices((prev) => [...prev, created]);
+      setForm({ code: '', name: '', description: '' });
+    } catch (e) {
+      console.error(e);
+      dispatch(
+        showToast({ message: 'Error al crear servicio', color: 'red' })
+      );
+    }
+  };
+
+  const handleAddExisting = async () => {
+    const svc = availableServices.find((s) => s.id === selectedExisting);
+    if (!svc) return;
+    try {
+      const created = await createPropertyService(propertyId, {
+        code: svc.code,
+        name: svc.name,
+        description: svc.description,
+      });
+      setServices((prev) => [...prev, created]);
+      setSelectedExisting('');
+    } catch (e) {
+      console.error(e);
+      dispatch(
+        showToast({ message: 'Error al agregar servicio', color: 'red' })
+      );
+    }
+  };
+
+  const handleUpdate = async (svc: PropertyService) => {
+    try {
+      const updated = await updatePropertyService(propertyId, svc.id, svc);
+      setServices((prev) =>
+        prev.map((s) => (s.id === updated.id ? updated : s))
+      );
+    } catch (e) {
+      console.error(e);
+      dispatch(
+        showToast({ message: 'Error al actualizar servicio', color: 'red' })
+      );
+    }
+  };
+
+  const handleDelete = async (id: number) => {
+    try {
+      await deletePropertyService(propertyId, id);
+      setServices((prev) => prev.filter((s) => s.id !== id));
+    } catch (e) {
+      console.error(e);
+      dispatch(
+        showToast({ message: 'Error al eliminar servicio', color: 'red' })
+      );
+    }
+  };
+
+  return (
+    <div className="bg-white dark:bg-dozegray/10 border border-gray-200 dark:border-white/10 rounded-xl p-6 shadow-sm space-y-6">
+      <h3 className="text-lg font-semibold text-dozeblue">Servicios de la propiedad</h3>
+
+      <div className="space-y-4">
+        <div className="flex flex-col sm:flex-row gap-2 items-start sm:items-end">
+          <select
+            value={selectedExisting}
+            onChange={(e) =>
+              setSelectedExisting(e.target.value ? Number(e.target.value) : '')
+            }
+            className="border border-gray-300 dark:border-white/20 rounded-md px-3 py-2 bg-white dark:bg-dozegray/10 text-sm"
+          >
+            <option value="">Seleccionar servicio existente</option>
+            {availableServices.map((svc) => (
+              <option key={svc.id} value={svc.id}>
+                {svc.name}
+              </option>
+            ))}
+          </select>
+          <button
+            onClick={handleAddExisting}
+            className="bg-dozeblue text-white px-4 py-2 rounded-md hover:bg-dozeblue/90"
+          >
+            Agregar existente
+          </button>
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+          <input
+            placeholder="Código"
+            value={form.code}
+            onChange={(e) => setForm({ ...form, code: e.target.value })}
+            className="border border-gray-300 dark:border-white/20 rounded-md px-3 py-2 bg-white dark:bg-dozegray/10 text-sm"
+          />
+          <input
+            placeholder="Nombre"
+            value={form.name}
+            onChange={(e) => setForm({ ...form, name: e.target.value })}
+            className="border border-gray-300 dark:border-white/20 rounded-md px-3 py-2 bg-white dark:bg-dozegray/10 text-sm"
+          />
+          <input
+            placeholder="Descripción"
+            value={form.description}
+            onChange={(e) =>
+              setForm({ ...form, description: e.target.value })
+            }
+            className="border border-gray-300 dark:border-white/20 rounded-md px-3 py-2 bg-white dark:bg-dozegray/10 text-sm col-span-1 sm:col-span-3"
+          />
+          <div className="col-span-1 sm:col-span-3">
+            <button
+              onClick={handleAdd}
+              className="mt-2 bg-dozeblue text-white px-4 py-2 rounded-md hover:bg-dozeblue/90"
+            >
+              Agregar nuevo
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        {services.map((svc) => (
+          <div
+            key={svc.id}
+            className="grid grid-cols-1 sm:grid-cols-4 gap-2 items-center"
+          >
+            <input
+              value={svc.code}
+              onChange={(e) =>
+                setServices((prev) =>
+                  prev.map((s) =>
+                    s.id === svc.id ? { ...s, code: e.target.value } : s
+                  )
+                )
+              }
+              className="border border-gray-300 dark:border-white/20 rounded-md px-3 py-2 bg-white dark:bg-dozegray/10 text-sm"
+            />
+            <input
+              value={svc.name}
+              onChange={(e) =>
+                setServices((prev) =>
+                  prev.map((s) =>
+                    s.id === svc.id ? { ...s, name: e.target.value } : s
+                  )
+                )
+              }
+              className="border border-gray-300 dark:border-white/20 rounded-md px-3 py-2 bg-white dark:bg-dozegray/10 text-sm"
+            />
+            <input
+              value={svc.description || ''}
+              onChange={(e) =>
+                setServices((prev) =>
+                  prev.map((s) =>
+                    s.id === svc.id
+                      ? { ...s, description: e.target.value }
+                      : s
+                  )
+                )
+              }
+              className="border border-gray-300 dark:border-white/20 rounded-md px-3 py-2 bg-white dark:bg-dozegray/10 text-sm"
+            />
+            <div className="flex gap-2">
+              <button
+                onClick={() => handleUpdate(svc)}
+                className="bg-dozeblue text-white px-3 py-2 rounded-md text-sm hover:bg-dozeblue/90"
+              >
+                Guardar
+              </button>
+              <button
+                onClick={() => handleDelete(svc.id)}
+                className="bg-red-500 text-white px-3 py-2 rounded-md text-sm hover:bg-red-600"
+              >
+                Eliminar
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="flex justify-end pt-4">
+        <button
+          onClick={onNext}
+          className="bg-dozeblue text-white px-6 py-2 rounded-md hover:bg-dozeblue/90 transition"
+        >
+          Continuar
+        </button>
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/staff/StepPropertyServices.tsx
+++ b/src/components/staff/StepPropertyServices.tsx
@@ -101,17 +101,17 @@ export default function StepPropertyServices({ propertyId, onNext }: Props) {
   };
 
   return (
-    <div className="bg-white dark:bg-dozegray/10 border border-gray-200 dark:border-white/10 rounded-xl p-6 shadow-sm space-y-6">
-      <h3 className="text-lg font-semibold text-dozeblue">Servicios de la propiedad</h3>
+    <div className="max-w-2xl mx-auto bg-white dark:bg-dozegray/10 border border-gray-200 dark:border-white/10 rounded-xl p-6 shadow-sm space-y-6">
+      <h3 className="text-lg font-semibold text-dozeblue text-center">Servicios de la propiedad</h3>
 
       <div className="space-y-4">
-        <div className="flex flex-col sm:flex-row gap-2 items-start sm:items-end">
+        <div className="flex flex-col sm:flex-row gap-2 items-center justify-center">
           <select
             value={selectedExisting}
             onChange={(e) =>
               setSelectedExisting(e.target.value ? Number(e.target.value) : '')
             }
-            className="border border-gray-300 dark:border-white/20 rounded-md px-3 py-2 bg-white dark:bg-dozegray/10 text-sm"
+            className="w-full sm:flex-1 border border-gray-300 dark:border-white/20 rounded-md px-3 py-2 bg-white dark:bg-dozegray/10 text-sm"
           >
             <option value="">Seleccionar servicio existente</option>
             {availableServices.map((svc) => (
@@ -122,24 +122,24 @@ export default function StepPropertyServices({ propertyId, onNext }: Props) {
           </select>
           <button
             onClick={handleAddExisting}
-            className="bg-dozeblue text-white px-4 py-2 rounded-md hover:bg-dozeblue/90"
+            className="w-full sm:w-auto bg-dozeblue text-white px-4 py-2 rounded-md hover:bg-dozeblue/90"
           >
             Agregar existente
           </button>
         </div>
 
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-2 justify-items-center">
           <input
             placeholder="Código"
             value={form.code}
             onChange={(e) => setForm({ ...form, code: e.target.value })}
-            className="border border-gray-300 dark:border-white/20 rounded-md px-3 py-2 bg-white dark:bg-dozegray/10 text-sm"
+            className="w-full border border-gray-300 dark:border-white/20 rounded-md px-3 py-2 bg-white dark:bg-dozegray/10 text-sm"
           />
           <input
             placeholder="Nombre"
             value={form.name}
             onChange={(e) => setForm({ ...form, name: e.target.value })}
-            className="border border-gray-300 dark:border-white/20 rounded-md px-3 py-2 bg-white dark:bg-dozegray/10 text-sm"
+            className="w-full border border-gray-300 dark:border-white/20 rounded-md px-3 py-2 bg-white dark:bg-dozegray/10 text-sm"
           />
           <input
             placeholder="Descripción"
@@ -147,12 +147,12 @@ export default function StepPropertyServices({ propertyId, onNext }: Props) {
             onChange={(e) =>
               setForm({ ...form, description: e.target.value })
             }
-            className="border border-gray-300 dark:border-white/20 rounded-md px-3 py-2 bg-white dark:bg-dozegray/10 text-sm col-span-1 sm:col-span-3"
+            className="w-full border border-gray-300 dark:border-white/20 rounded-md px-3 py-2 bg-white dark:bg-dozegray/10 text-sm col-span-1 sm:col-span-3"
           />
-          <div className="col-span-1 sm:col-span-3">
+          <div className="col-span-1 sm:col-span-3 flex justify-center">
             <button
               onClick={handleAdd}
-              className="mt-2 bg-dozeblue text-white px-4 py-2 rounded-md hover:bg-dozeblue/90"
+              className="mt-2 w-full sm:w-auto bg-dozeblue text-white px-4 py-2 rounded-md hover:bg-dozeblue/90"
             >
               Agregar nuevo
             </button>
@@ -160,7 +160,7 @@ export default function StepPropertyServices({ propertyId, onNext }: Props) {
         </div>
       </div>
 
-      <div className="space-y-2">
+      <div className="space-y-2 max-h-48 overflow-y-auto">
         {services.map((svc) => (
           <div
             key={svc.id}
@@ -175,7 +175,7 @@ export default function StepPropertyServices({ propertyId, onNext }: Props) {
                   )
                 )
               }
-              className="border border-gray-300 dark:border-white/20 rounded-md px-3 py-2 bg-white dark:bg-dozegray/10 text-sm"
+              className="w-full border border-gray-300 dark:border-white/20 rounded-md px-3 py-2 bg-white dark:bg-dozegray/10 text-sm"
             />
             <input
               value={svc.name}
@@ -186,7 +186,7 @@ export default function StepPropertyServices({ propertyId, onNext }: Props) {
                   )
                 )
               }
-              className="border border-gray-300 dark:border-white/20 rounded-md px-3 py-2 bg-white dark:bg-dozegray/10 text-sm"
+              className="w-full border border-gray-300 dark:border-white/20 rounded-md px-3 py-2 bg-white dark:bg-dozegray/10 text-sm"
             />
             <input
               value={svc.description || ''}
@@ -199,7 +199,7 @@ export default function StepPropertyServices({ propertyId, onNext }: Props) {
                   )
                 )
               }
-              className="border border-gray-300 dark:border-white/20 rounded-md px-3 py-2 bg-white dark:bg-dozegray/10 text-sm"
+              className="w-full border border-gray-300 dark:border-white/20 rounded-md px-3 py-2 bg-white dark:bg-dozegray/10 text-sm"
             />
             <div className="flex gap-2">
               <button

--- a/src/services/propertiesApi.ts
+++ b/src/services/propertiesApi.ts
@@ -1,6 +1,10 @@
 import { ApiResponse } from '@/constants/responseCodes';
 import axios from './axios';
-import { Property, PropertyFormData } from '@/types/property';
+import {
+  Property,
+  PropertyFormData,
+  PropertyService,
+} from '@/types/property';
 import { Room } from '@/types/room';
 import { AvailabilityPayload, AvailabilityResponse } from '@/types/roomType';
 
@@ -106,5 +110,56 @@ export async function uploadPropertyImage(
 }
 export const fetchAllProperties = async (): Promise<Property[]> => {
   const response = await axios.get(`/properties/`);
+  return response.data;
+};
+
+export const getPropertyServices = async (
+  propertyId: number
+): Promise<PropertyService[]> => {
+  const response = await axios.get(
+    `/properties/my/${propertyId}/services`,
+    { withCredentials: true }
+  );
+  return response.data;
+};
+
+export const createPropertyService = async (
+  propertyId: number,
+  data: { code: string; name: string; description?: string }
+): Promise<PropertyService> => {
+  const response = await axios.post(
+    `/properties/my/${propertyId}/services`,
+    data,
+    { withCredentials: true }
+  );
+  return response.data;
+};
+
+export const updatePropertyService = async (
+  propertyId: number,
+  serviceId: number,
+  data: { code: string; name: string; description?: string }
+): Promise<PropertyService> => {
+  const response = await axios.put(
+    `/properties/my/${propertyId}/services/${serviceId}`,
+    data,
+    { withCredentials: true }
+  );
+  return response.data;
+};
+
+export const deletePropertyService = async (
+  propertyId: number,
+  serviceId: number
+): Promise<void> => {
+  await axios.delete(`/properties/my/${propertyId}/services/${serviceId}`, {
+    withCredentials: true,
+  });
+};
+
+export const fetchAllServices = async (): Promise<PropertyService[]> => {
+  const response = await axios.get('/properties/services', {
+    withCredentials: true,
+  });
   return response.data;
 };

--- a/src/types/property.ts
+++ b/src/types/property.ts
@@ -1,5 +1,12 @@
 import { RoomType } from './roomType';
 
+export interface PropertyService {
+  id: number;
+  code: string;
+  name: string;
+  description?: string;
+}
+
 export interface Property {
   id: number;
   name: string;
@@ -10,6 +17,7 @@ export interface Property {
   cover_image: string;
   images: string[];
   room_types: RoomType[];
+  services?: PropertyService[];
   communication_methods: string[];
   location: string;
   terms_and_conditions: {


### PR DESCRIPTION
## Summary
- add property services types and API functions
- integrate new property services step into add property wizard
- allow staff to create, edit, delete and reuse property services

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893f3dacff4832989cb7d0e7f4dd707