### PR TITLE
feat: allow editing property services

### DIFF
--- a/src/components/staff/StepPropertyServices.tsx
+++ b/src/components/staff/StepPropertyServices.tsx
@@ -15,7 +15,12 @@ import {
 
 interface Props {
   propertyId: number;
-  onNext: () => void;
+  /**
+   * Optional callback used when this component is rendered as a step within the
+   * property creation wizard. When omitted (e.g. inside the edit modal) the
+   * "Continuar" button is hidden and actions happen immediately.
+   */
+  onNext?: () => void;
 }
 
 export default function StepPropertyServices({ propertyId, onNext }: Props) {
@@ -255,14 +260,16 @@ export default function StepPropertyServices({ propertyId, onNext }: Props) {
         </div>
       </div>
 
-      <div className="flex justify-end pt-4">
-        <button
-          onClick={onNext}
-          className="bg-dozeblue text-white px-6 py-2 rounded-md hover:bg-dozeblue/90 transition"
-        >
-          Continuar
-        </button>
-      </div>
+      {onNext && (
+        <div className="flex justify-end pt-4">
+          <button
+            onClick={onNext}
+            className="bg-dozeblue text-white px-6 py-2 rounded-md hover:bg-dozeblue/90 transition"
+          >
+            Continuar
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/ui/cards/PropertiesCard/PropertyStaff/PropertyEditModal.tsx
+++ b/src/components/ui/cards/PropertiesCard/PropertyStaff/PropertyEditModal.tsx
@@ -7,6 +7,7 @@ import type { Property, PropertyFormData } from '@/types/property';
 import StepBasicInfo from './StepBasicInfo';
 import StepImages from './StepImages';
 import StepSync from './StepSync';
+import StepPropertyServices from '@/components/staff/StepPropertyServices';
 
 interface Props {
   open: boolean;
@@ -15,9 +16,8 @@ interface Props {
 }
 
 export default function PropertyEditModal({ open, onClose, property }: Props) {
-  const [activeTab, setActiveTab] = useState<'info' | 'images' | 'sync'>(
-    'info'
-  );
+  const [activeTab, setActiveTab] =
+    useState<'info' | 'images' | 'services' | 'sync'>('info');
 
   const propertyId = property.id;
 
@@ -58,6 +58,7 @@ export default function PropertyEditModal({ open, onClose, property }: Props) {
           {[
             { key: 'info', label: 'Información' },
             { key: 'images', label: 'Imágenes' },
+            { key: 'services', label: 'Servicios' },
             { key: 'sync', label: 'Sincronizar PMS' },
           ].map((tab) => (
             <button
@@ -108,6 +109,18 @@ export default function PropertyEditModal({ open, onClose, property }: Props) {
                   setForm={setForm}
                   propertyId={propertyId}
                 />
+              </motion.div>
+            )}
+            {activeTab === 'services' && (
+              <motion.div
+                key="services"
+                initial={{ opacity: 0, x: 30 }}
+                animate={{ opacity: 1, x: 0 }}
+                exit={{ opacity: 0, x: -30 }}
+                transition={{ duration: 0.2 }}
+                className="absolute inset-0"
+              >
+                <StepPropertyServices propertyId={propertyId} />
               </motion.div>
             )}
             {activeTab === 'sync' && (


### PR DESCRIPTION
## Summary
- allow StepPropertyServices to be reused without a next step
- add services tab to property edit modal

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68941736da208329a5adbc4f5effa985